### PR TITLE
Bugfix: +1 on read was throwing off accuracy

### DIFF
--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -184,7 +184,7 @@ void Servo::release()
 
 int Servo::read() // return the value as degrees
 {
-    return (map(readMicroseconds()+1, this->min, this->max, 0, 180));
+    return (map(readMicroseconds(), this->min, this->max, 0, 180));
 }
 
 int Servo::readMicroseconds()


### PR DESCRIPTION
Noticed that when reading the current value, incrementing or decrementing it by one, and then writing it back, the servo only moved in one direction.  Turned out this +1 on the read was throwing off the accuracy, and there's no -1 on the write.