### PR TITLE
Expose ticks for incremental adjustment of servo

### DIFF
--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -161,15 +161,18 @@ void Servo::write(int value)
 
 void Servo::writeMicroseconds(int value)
 {
+    writeTicks(usToTicks(value));  // convert to ticks
+}
+
+void Servo::writeTicks(int value)
+{
     // calculate and store the values for the given channel
     if (this->attached())   // ensure channel is valid
     {
-        if (value < this->min)          // ensure pulse width is valid
-            value = this->min;
-        else if (value > this->max)
-            value = this->max;
-
-        value = usToTicks(value);  // convert to ticks
+        if (value < usToTicks(this->min))      // ensure ticks are in range
+            value = usToTicks(this->min);
+        else if (value > usToTicks(this->max))
+            value = usToTicks(this->max);
         this->ticks = value;
         // do the actual write
         pwm.write( this->ticks);
@@ -200,6 +203,11 @@ int Servo::readMicroseconds()
     }
 
     return (pulsewidthUsec);
+}
+
+int Servo::readTicks()
+{
+    return this->ticks;
 }
 
 bool Servo::attached()

--- a/src/ESP32Servo.h
+++ b/src/ESP32Servo.h
@@ -136,9 +136,11 @@ public:
 	void detach();
 	void write(int value); // if value is < MIN_PULSE_WIDTH its treated as an angle, otherwise as pulse width in microseconds
 	void writeMicroseconds(int value);     // Write pulse width in microseconds
+	void writeTicks(int value);     // Write ticks, the smallest increment the servo can handle
 	void release();
 	int read(); // returns current pulse width as an angle between 0 and 180 degrees
 	int readMicroseconds(); // returns current pulse width in microseconds for this servo
+	int readTicks(); // returns current ticks, the smallest increment the servo can handle
 	bool attached(); // return true if this servo is attached, otherwise false
 
 	// ESP32 only functions


### PR DESCRIPTION
This change is made for joystick adaptation where we just need to be able to move the servo forward and backwards, but also keep within the limits of the servo.